### PR TITLE
Updated to latest version of the `amazon-location-utilities-auth-helper-js` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.0
+
+### ✨ Features and improvements
+
+- Updated to latest version of `amazon-location-utilities-auth-helper-js` which contains support for Amazon Cognito with standalone Maps SDK URLs and modified the `withAPIKey` method to be synchronous
+
 # 1.1.1
 
 ### 🐞 Bug fixes

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This example uses the Amazon Location Client to make a request that authenticate
 
 ```javascript
 // Create an authentication helper instance using an API key and region
-const authHelper = await amazonLocationClient.withAPIKey("<API Key>", "<Region>");
+const authHelper = amazonLocationClient.withAPIKey("<API Key>", "<Region>");
 
 const client = new amazonLocationClient.GeoRoutesClient(authHelper.getClientConfig());
 const input = { ... };
@@ -63,7 +63,7 @@ The standalone Maps SDK commands are grouped into a `maps` namespace. For exampl
 
 ```javascript
 // Create an authentication helper instance using an API key and region
-const authHelper = await amazonLocationClient.withAPIKey("<API Key>", "<Region>");
+const authHelper = amazonLocationClient.withAPIKey("<API Key>", "<Region>");
 
 const client = new amazonLocationClient.GeoMapsClient(authHelper.getClientConfig());
 const input = { ... };
@@ -77,7 +77,7 @@ The standalone Places SDK commands are grouped into a `places` namespace. For ex
 
 ```javascript
 // Create an authentication helper instance using an API key and region
-const authHelper = await amazonLocationClient.withAPIKey("<API Key>", "<Region>");
+const authHelper = amazonLocationClient.withAPIKey("<API Key>", "<Region>");
 
 const client = new amazonLocationClient.GeoPlacesClient(authHelper.getClientConfig());
 const input = { ... };
@@ -91,7 +91,7 @@ The standalone Routes SDK commands are grouped into a `routes` namespace. For ex
 
 ```javascript
 // Create an authentication helper instance using an API key and region
-const authHelper = await amazonLocationClient.withAPIKey("<API Key>", "<Region>");
+const authHelper = amazonLocationClient.withAPIKey("<API Key>", "<Region>");
 
 const client = new amazonLocationClient.GeoRoutesClient(authHelper.getClientConfig());
 const input = { ... };
@@ -105,7 +105,7 @@ The Location SDK commands are under the top-level namespace. For example:
 
 ```javascript
 // Create an authentication helper instance using an API key and region
-const authHelper = await amazonLocationClient.withAPIKey("<API Key>", "<Region>");
+const authHelper = amazonLocationClient.withAPIKey("<API Key>", "<Region>");
 
 const client = new amazonLocationClient.LocationClient(authHelper.getClientConfig());
 const input = { ... };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-client",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-client",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-geo-maps": "^3.683.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "@aws-sdk/client-geo-places": "^3.683.0",
         "@aws-sdk/client-geo-routes": "^3.683.0",
         "@aws-sdk/client-location": "^3.682.0",
-        "@aws-sdk/credential-providers": "^3.682.0",
-        "@aws/amazon-location-utilities-auth-helper": "^1.1.0"
+        "@aws-sdk/credential-providers": "^3.685.0",
+        "@aws/amazon-location-utilities-auth-helper": "^1.2.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.682.0.tgz",
-      "integrity": "sha512-BD8PPPk3+ZzFqCJSPraoXkgRcPTtjguXtyDYsyBMzFofWmN4YeswXSavZVAC354W98mkffDaXBvieyqu1Y9fKA==",
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.685.0.tgz",
+      "integrity": "sha512-4h+aw0pUEOVP77TpF1ec9AX0mzotsiw2alXfh+P0t+43eg2EjaKRftRpNXyt5XmUPws+wsH10uEL4CzSZo1sxQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -572,11 +572,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.682.0.tgz",
-      "integrity": "sha512-V+y4qUQtc0kTnNR7u5LwnZn8EZk2pjdNX+84MwD9VjXekqbXikADu06Mj93kVGVW+qgqtNMvJ8PpiI3EaaxC7A==",
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.685.0.tgz",
+      "integrity": "sha512-qw9s09JFhJxEkmbo1gn94pAtyLHSx8YBX2qqrL6v3BdsJbP2fnRJMMssGMGR4jPyhklh5TSgZo0FzflbqJU8sw==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.682.0",
+        "@aws-sdk/client-cognito-identity": "3.685.0",
         "@aws-sdk/types": "3.679.0",
         "@smithy/property-provider": "^3.1.7",
         "@smithy/types": "^3.5.0",
@@ -721,15 +721,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.682.0.tgz",
-      "integrity": "sha512-vLBdUlTISEXVKYFFO665ajC0U0RdXFx21fwTHiN2g4edFH++di2XCJ8/Y34bu09z9bV/rwFT2jn41iAVWasNKg==",
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.685.0.tgz",
+      "integrity": "sha512-pIXNNwPG2KnzjGYYbADquEkROuKxAJxuWt87TJO7LCFqKwb5l6h0Mc7yc4j13zxOVd/EhXD0VsPeqnobDklUoQ==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.682.0",
+        "@aws-sdk/client-cognito-identity": "3.685.0",
         "@aws-sdk/client-sso": "3.682.0",
         "@aws-sdk/client-sts": "3.682.0",
         "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.682.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.685.0",
         "@aws-sdk/credential-provider-env": "3.679.0",
         "@aws-sdk/credential-provider-http": "3.679.0",
         "@aws-sdk/credential-provider-ini": "3.682.0",
@@ -911,9 +911,9 @@
       }
     },
     "node_modules/@aws/amazon-location-utilities-auth-helper": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws/amazon-location-utilities-auth-helper/-/amazon-location-utilities-auth-helper-1.1.0.tgz",
-      "integrity": "sha512-hPGQkgGCPFVI3iMAkann5kzMzPmpMu+Lh2PwMXZ8p247MtRoYHCavAsFb7Cq+KPJpiDZe+yR/KZut5oqkXLSkw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@aws/amazon-location-utilities-auth-helper/-/amazon-location-utilities-auth-helper-1.2.0.tgz",
+      "integrity": "sha512-bIsbwpvQG/uEDGYlvLgBwEFKWZ9f/LFhWsGWYwqhVew4GvDLzC5HZlVU1zHIFFpuo5e4gY5o6y7JBRA0f33q6Q==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/credential-providers": "^3.682.0",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
   "lint-staged": {},
   "dependencies": {
     "@aws-sdk/client-location": "^3.682.0",
-    "@aws-sdk/credential-providers": "^3.682.0",
+    "@aws-sdk/credential-providers": "^3.685.0",
     "@aws-sdk/client-geo-maps": "^3.683.0",
     "@aws-sdk/client-geo-places": "^3.683.0",
     "@aws-sdk/client-geo-routes": "^3.683.0",
-    "@aws/amazon-location-utilities-auth-helper": "^1.1.0"
+    "@aws/amazon-location-utilities-auth-helper": "^1.2.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-client",
   "description": "Amazon Location Client Bundle",
   "license": "Apache-2.0",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
## Description
Updated to the latest version (`1.2.0`) of the `amazon-location-utilities-auth-helper-js` dependency, which includes:
* Support for Amazon Cognito with standalone Maps SDK URLs
* Modified the `withAPIKey` method to be synchronous

Updated the `README` to no longer use `await` when retrieving credentials using the `withAPIKey` method. Also updated to the latest version of the `@aws-sdk/credential-providers` dependency.

Will release a new version of this package as `1.2.0` and updated the `CHANGELOG` accordingly.

## Testing
Tested the `amazon-location-samples-js` with Amazon Cognito and API Key use-cases using a locally built version of this package and verified the samples work as intended.