### PR TITLE
Added severity and impact fields to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,67 +1,102 @@
 ---
-name: "🐛 Bug Report"
-description: Report a bug
-title: "(short issue description)"
-labels: [bug, needs-triage]
-assignees: []
-body:
-  - type: textarea
-    id: description
-    attributes:
-      label: Describe the bug
-      description: What is the problem? A clear and concise description of the bug.
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-      description: |
-        What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    id: current
-    attributes:
-      label: Current Behavior
-      description: |
-        What actually happened?
-
-        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
-        If service responses are relevant, please include wire logs.
-    validations:
-      required: true
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Reproduction Steps
-      description: |
-        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
-        For more complex issues provide a repo with the smallest sample that reproduces the bug.
-
-        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
-        The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
-    validations:
-      required: true
-  - type: textarea
-    id: solution
-    attributes:
-      label: Possible Solution
-      description: |
-        Suggest a fix/reason for the bug
-    validations:
-      required: false
-  - type: textarea
-    id: context
-    attributes:
-      label: Additional Information/Context
-      description: |
-        Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
-    validations:
-      required: false
-  - type: input
-    id: environment
-    attributes:
-      label: Environment details (OS name and version, browser, etc.)
-    validations:
-      required: true
+  name: "🐛 Bug Report"
+  description: Report a bug
+  title: "(short issue description)"
+  labels: [bug, needs-triage]
+  assignees: []
+  body:
+    - type: textarea
+      id: description
+      attributes:
+        label: Describe the bug
+        description: What is the problem? A clear and concise description of the bug.
+      validations:
+        required: true
+  
+    - type: textarea
+      id: expected
+      attributes:
+        label: Expected Behavior
+        description: |
+          What did you expect to happen?
+      validations:
+        required: true
+  
+    - type: textarea
+      id: current
+      attributes:
+        label: Current Behavior
+        description: |
+          What actually happened?
+  
+          Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+          If service responses are relevant, please include wire logs.
+      validations:
+        required: true
+  
+    - type: dropdown
+      id: severity
+      attributes:
+        label: Technical Severity
+        description: How serious is this issue from a technical perspective?
+        options:
+          - S1 - Critical (System crash, data loss, security vulnerability)
+          - S2 - Major (Significant functional failure, severe performance issue)
+          - S3 - Moderate (Partial feature malfunction, UI/UX problems)
+          - S4 - Minor (Cosmetic issues, typos, non-critical bugs)
+      validations:
+        required: true
+  
+    - type: dropdown
+      id: impact
+      attributes:
+        label: User Impact
+        description: How many users are affected by this issue?
+        options:
+          - All users
+          - Most users (>50%)
+          - Many users (25-50%)
+          - Some users (5-25%)
+          - Few users (<5%)
+          - Single user/edge case
+      validations:
+        required: true
+  
+    - type: textarea
+      id: reproduction
+      attributes:
+        label: Reproduction Steps
+        description: |
+          Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
+          For more complex issues provide a repo with the smallest sample that reproduces the bug.
+  
+          Avoid including business logic or unrelated code, it makes diagnosis more difficult.
+          The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
+      validations:
+        required: true
+  
+    - type: textarea
+      id: solution
+      attributes:
+        label: Possible Solution
+        description: |
+          Suggest a fix/reason for the bug
+      validations:
+        required: false
+  
+    - type: textarea
+      id: context
+      attributes:
+        label: Additional Information/Context
+        description: |
+          Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
+      validations:
+        required: false
+  
+    - type: input
+      id: environment
+      attributes:
+        label: Environment details (OS name and version, browser, etc.)
+      validations:
+        required: true
+  


### PR DESCRIPTION
### Description
Added dropdown fields to the issue template for reporting user to input both:
* Technical Severity - How serious is this issue?
* Impact - How many users are affected by this issue?

Prettify ran on the file as well, which resulted in whitespace changes that render as a replacement when it was really just fixing up whitespace on the beginning of the lines.