### PR TITLE
fix: update package configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "Raymond Lee <imraylee@amazon.com>"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.0.0"
   },
   "browser": "./dist/amazonLocationClient.js",
   "main": "./dist/cjs/amazonLocationClient.cjs",
-  "module": "./src/index.mjs",
   "unpkg": "./dist/amazonLocationClient.js",
   "type": "module",
+  "sideEffects": false,
   "files": [
     "./LICENSE.txt",
     "./CODE_OF_CONDUCT.md",
@@ -43,7 +43,6 @@
     "clean": "rm -rf dist",
     "test": "jest --collectCoverage --collectCoverageFrom=src/*.{mjs}",
     "build": "rollup -c",
-    "prepare": "husky install",
     "prepublishOnly": "npm-run-all clean build"
   },
   "jest": {
@@ -58,7 +57,6 @@
       "package.json"
     ]
   },
-  "lint-staged": {},
   "dependencies": {
     "@aws-sdk/client-location": "^3.992.0",
     "@aws-sdk/credential-providers": "^3.992.0",
@@ -73,9 +71,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-terser": "^1.0.0",
-    "husky": "^9.1.6",
     "jest": "^29.7.0",
-    "lint-staged": "^15.2.10",
     "npm-run-all2": "^7.0.1",
     "rollup": "^4.24.0"
   }


### PR DESCRIPTION
## Description

  Fixes package configuration issues:

  - Update Node.js engine requirement from 16.x to 18.x (16.x reached EOL September 2023)
  - Remove invalid `module` field pointing to unpublished `src/` directory
  - Add `sideEffects: false` for better tree-shaking support
  - Remove unused husky and lint-staged dependencies
  - Rebuild dist to include `withCredentialProvider` export in CJS bundle (was missing despite being in source)

  ## Testing

  - All tests passing (3/3)
  - Manual verification: loaded bundle via script tag, confirmed all exports present including `withCredentialProvider`
  - Build completes successfully, both CJS and UMD bundles generated correctly

  No breaking changes - internal configuration fixes only.