### PR TITLE
chore: release version 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.3.2
+
+### 🐞 Bug fixes
+
+- Fixed package configuration issues:
+  - Updated Node.js engine requirement from 16.x to 18.x (16.x reached EOL September 2023)
+  - Removed invalid `module` field pointing to unpublished `src/` directory
+  - Added `sideEffects: false` for better tree-shaking support
+  - Removed unused husky and lint-staged dependencies
+  - Rebuilt dist to include `withCredentialProvider` export in CJS bundle (was missing despite being in source)
+
 # 1.3.1
 
 ### ✨ Features and improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-client",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-client",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-geo-maps": "^3.992.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-client",
   "description": "Amazon Location Client Bundle",
   "license": "Apache-2.0",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
Release version 1.3.2

Includes:
- Package configuration fixes from #50
- Updated CHANGELOG
- Version bump to 1.3.2